### PR TITLE
feat: add Architecture‑as‑Code scaffold

### DIFF
--- a/.github/workflows/render-diagrams.yml
+++ b/.github/workflows/render-diagrams.yml
@@ -1,0 +1,37 @@
+name: Render C4 Diagrams
+on:
+  push:
+    paths:
+      - "docs/c4/*.mmd"
+      - ".github/workflows/render-diagrams.yml"
+  pull_request:
+    paths:
+      - "docs/c4/*.mmd"
+      - ".github/workflows/render-diagrams.yml"
+permissions:
+  contents: read
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install mermaid-cli
+        run: npm -g install @mermaid-js/mermaid-cli
+      - name: Render PNG & SVG
+        run: |
+          mkdir -p docs/c4
+          for f in docs/c4/*.mmd; do
+            base=$(basename "$f" .mmd)
+            mmdc -i "$f" -o "docs/c4/${base}.png" -b transparent
+            mmdc -i "$f" -o "docs/c4/${base}.svg" -b transparent
+          done
+      - name: Upload diagrams
+        uses: actions/upload-artifact@v4
+        with:
+          name: c4-diagrams
+          path: |
+            docs/c4/*.png
+            docs/c4/*.svg

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# OS / editor
+.DS_Store
+Thumbs.db
+.vscode/
+.idea/
+# Node (for mermaid-cli in CI if run locally)
+node_modules/
+# Build artifacts (we upload from CI instead of committing)
+docs/c4/*.png
+docs/c4/*.svg

--- a/README.md
+++ b/README.md
@@ -1,70 +1,32 @@
-Here’s a clean **root `README.md`** you can drop in so the GitHub landing page clearly explains **UnityOps\_Model**.
+# UnityOps Model – Architecture as Code
 
----
+This repo stores the **official software architecture** for UnityOps using **Architecture as Code (AaC)**.
 
-```markdown
-# UnityOps_Model
+## What’s here
+- **C4 diagrams** (Mermaid) in `docs/c4`
+- **Architecture Decision Records (ADRs)** in `docs/adr`
+- **Non‑functional requirements** in `docs/non-functional-requirements.md`
+- **Glossary** in `docs/glossary.md`
+- **CI** renders diagrams on every push and uploads them as build artifacts
 
-**UnityOps_Model** is the **context repository** for the UnityOps system.  
-It is the single source of truth for *what* we are building and *why* — before any code, infrastructure, or DSL modeling.
+## Edit flow
+1) Propose changes in a branch.
+2) Update C4 Mermaid files and/or ADRs.
+3) Run PR; CI will render and attach **PNG/SVG** of every diagram.
+4) Review diffs (text + rendered diagrams). Merge when approved.
 
----
-
-## 📜 Purpose
-- Capture the **vision**, **principles**, and **constraints** that guide UnityOps.
-- Define **capabilities**, **personas**, and **use cases** in business terms.
-- Establish **non-functional requirements** (NFRs) and **success metrics**.
-- Maintain a **governance trail** through ADRs and readiness checklists.
-
-This repo contains **no application code**. It exists to keep design and implementation aligned with the agreed business context.
-
----
-
-## 📂 Structure
+## Local preview (optional)
+```bash
+# Requires Node 18+
+npm -g install @mermaid-js/mermaid-cli
+mmdc -i docs/c4/01-context.mmd -o docs/c4/01-context.png
 ```
 
-/context/                # Vision, principles, capabilities, use-cases, domain language
-/context/use-cases/      # Business scenarios in Gherkin + acceptance criteria
-/context/domain/         # Ubiquitous language and bounded contexts
-/adr/                    # Architecture Decision Records
-/schemas/                # JSON Schema for machine-validating context files
-/.github/workflows/      # CI jobs for context validation
+## Files of interest
 
-```
-
----
-
-## 🚦 Workflow
-1. **Draft Context** → Fill out `context/` files for a use case.
-2. **Validate** → PR triggers CI to check file completeness + schema compliance.
-3. **Review & Approve** → Merge when readiness checklist is ✅.
-4. **Gate** → Only after a use case is “Context Ready” can model framework (DSL) work begin.
-
----
-
-## ✅ Readiness Checklist (per use case)
-- Vision & measurable outcomes defined
-- Persona & scenarios written
-- Capability marked as “approved”
-- Principles & constraints reviewed
-- NFRs & risks documented
-- ADR(s) added if needed
-
-See [`context/readiness-checklist.md`](context/readiness-checklist.md) for details.
-
----
-
-## 🗂 Related Repositories
-- **UnityOps** — Application code (portal, API, agent)
-- **UnityOps_Infrastructure** — Bicep/IaC definitions
-- **UnityOps_Model** *(this repo)* — Context and business model
-
----
-
-## 📄 License
-[MIT License](LICENSE) — unless otherwise stated in individual files.
-```
-
----
-
-Do you want me to also add a **short “About” description** for the GitHub sidebar so it shows up next to the repo name? That way people see the purpose even without opening the README.
+* `docs/c4/01-context.mmd` – System Context (L1)
+* `docs/c4/02-container.mmd` – Containers (L2)
+* `docs/c4/03-component-example.mmd` – Component example (L3)
+* `docs/adr/0000-template.md` – ADR template
+* `docs/adr/0001-adopt-architecture-as-code.md`
+* `docs/adr/0002-choose-c4-mermaid.md`

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,8 @@
+# ADR NNNN: Title
+
+* **Date:** YYYY-MM-DD
+* **Status:** Proposed | Accepted | Superseded by NNNN
+* **Context**
+* **Decision**
+* **Consequences**
+* **Alternatives considered**

--- a/docs/adr/0001-adopt-architecture-as-code.md
+++ b/docs/adr/0001-adopt-architecture-as-code.md
@@ -1,0 +1,23 @@
+# ADR 0001: Adopt Architecture as Code (AaC)
+
+* **Date:** 2025-08-20
+* **Status:** Accepted
+
+## Context
+
+Architecture drifts without source control and repeatable rendering.
+
+## Decision
+
+Use Git as the **single source of truth** for architecture (diagrams + docs).
+Store diagrams as **Mermaid** text; docs as **Markdown**; track decisions as **ADRs**.
+
+## Consequences
+
+* ✔ Reviewable diffs, reproducible diagrams, CI rendering
+* ✖ Requires minimal tooling (Mermaid CLI in CI)
+
+## Alternatives
+
+* Static images (no diffs)
+* Wiki-only documentation (not reviewable as code)

--- a/docs/adr/0002-choose-c4-mermaid.md
+++ b/docs/adr/0002-choose-c4-mermaid.md
@@ -1,0 +1,22 @@
+# ADR 0002: Choose C4 + Mermaid for modeling
+
+* **Date:** 2025-08-20
+* **Status:** Accepted
+
+## Context
+
+We need layered views and portable, text-first diagrams.
+
+## Decision
+
+Adopt **C4 views** (L1–L3) rendered with **Mermaid** (broad tool support).
+
+## Consequences
+
+* ✔ Team can edit in any editor; CI renders previews
+* ✖ Mermaid C4 extension varies by renderer; we maintain compatibility via flowcharts
+
+## Alternatives
+
+* PlantUML C4 (excellent, JVM requirement)
+* UML-only (loses pragmatic C4 views)

--- a/docs/c4/01-context.mmd
+++ b/docs/c4/01-context.mmd
@@ -1,0 +1,29 @@
+%%{init: {"theme":"default"}}%%
+%% If your renderer supports Mermaid C4 (C4Context), feel free to switch.
+%% We use standard flowchart for maximum compatibility.
+
+flowchart TB
+title: UnityOps – Level 1: System Context
+
+user(["Stakeholder / Operator"]):::person
+extMES([MES - Shop-floor Events]):::system
+extERP([ERP - Orders & Inventory]):::system
+extIDP([ID Provider - SSO/OIDC]):::system
+
+subgraph UnityOps Platform :::system
+ai([AI Orchestrator<br/>Chat + Agents]):::system
+bi([BI Layer<br/>Semantic Models & Dashboards]):::system
+qc([QC / Forms Service<br/>Validations & Data Capture]):::system
+bus([Internal Message Bus / Router]):::system
+end
+
+user -->|"Plan / Operate"| ai
+ai -->|"Queries / Models"| bi
+ai -->|"Generate forms / checks"| qc
+bi -->|"KPIs / Reports"| user
+qc -->|"Results / Exceptions"| bi
+bi <--->|Read/Write| extERP
+qc -->|Telemetry| extMES
+user -->|"SSO/OIDC"| extIDP
+classDef person stroke:#111,stroke-width:2,stroke-dasharray:3 3
+classDef system fill:#f5f5f5,stroke:#666,stroke-width:1.2

--- a/docs/c4/02-container.mmd
+++ b/docs/c4/02-container.mmd
@@ -1,0 +1,41 @@
+%%{init: {"theme":"default"}}%%
+flowchart LR
+title: UnityOps – Level 2: Container Diagram
+
+subgraph Browser
+webUI["Blazor Server UI"]:::container
+end
+
+subgraph Backend
+api["ASP.NET API Service"]:::container
+orchestrator["AI Orchestrator (Chat + Agents)"]:::container
+router["Kong / Internal Router"]:::container
+events["Event Store (e.g., Kafka/Redpanda)"]:::container
+jobs["Worker Service (Windows Service)"]:::container
+end
+
+subgraph Data
+coldb["Columnar Warehouse (ClickHouse)"]:::container
+rdb["Relational DB (PostgreSQL)"]:::container
+obj["Object Storage (Artifacts)"]:::container
+end
+
+extMES([MES]):::system
+extERP([ERP]):::system
+extIDP([SSO/OIDC]):::system
+
+webUI --> api
+api --> orchestrator
+api --> router
+router <--> orchestrator
+orchestrator --> events
+jobs --> events
+api <--> rdb
+api <--> coldb
+api --> obj
+api -->|SSO| extIDP
+router <--> extMES
+api <--> extERP
+
+classDef container fill:#eef7ff,stroke:#246,stroke-width:1.5
+classDef system fill:#f5f5f5,stroke:#666,stroke-width:1.2

--- a/docs/c4/03-component-example.mmd
+++ b/docs/c4/03-component-example.mmd
@@ -1,0 +1,20 @@
+%%{init: {"theme":"default"}}%%
+flowchart TB
+title: UnityOps – Level 3: Component View (API Service)
+
+subgraph API Service :::container
+ctrl["Controllers"]:::component
+svc["Application Services"]:::component
+repo["Repositories"]:::component
+pol["Policy/Authorization"]:::component
+dto["DTO / Contracts"]:::component
+end
+
+svc --> repo
+ctrl --> svc
+ctrl --> pol
+repo --> rdb[(PostgreSQL)]
+repo --> ch[(ClickHouse)]
+svc --> bus[(Message Bus)]
+classDef component fill:#fef7e0,stroke:#864,stroke-width:1.2
+classDef container fill:#eef7ff,stroke:#246,stroke-width:1.5

--- a/docs/c4/legend.mmd
+++ b/docs/c4/legend.mmd
@@ -1,0 +1,7 @@
+%% Mermaid "legend" for C4 styling hints used in this repo
+flowchart LR
+classDef person stroke-width:2,stroke-dasharray:2 2
+classDef system fill:#f5f5f5,stroke:#666,stroke-width:1.5
+classDef container fill:#eef7ff,stroke:#246,stroke-width:1.5
+classDef component fill:#fef7e0,stroke:#864,stroke-width:1.2
+note>Use these class names in nodes: person, system, container, component]

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,7 @@
+# Glossary
+
+* **AaC:** Architecture as Code.
+* **ADR:** Architecture Decision Record.
+* **C4:** Context/Container/Component/Code views.
+* **UnityOps:** Internal platform combining AI, BI, and QC workflows.
+* **Router:** Internal command/messaging gateway (e.g., Kong).

--- a/docs/non-functional-requirements.md
+++ b/docs/non-functional-requirements.md
@@ -1,0 +1,11 @@
+# Non-Functional Requirements (NFRs)
+
+> Track the qualities that drive architecture.
+
+* **Availability:** target 99.9% (three-nines) for UI and API.
+* **Performance:** P95 UI latency < 300 ms; API < 200 ms (intra-DC).
+* **Scalability:** horizontal for API/workers; BI queries via columnar store.
+* **Security:** OIDC/OAuth2; role-based auth; audit for data mutations.
+* **Observability:** logs, metrics, traces; SLOs for core endpoints.
+* **Data:** GDPR/PII tagging; lineage (ELT jobs), retention classes.
+* **Reliability:** idempotent workers; DLQ on bus; at-least-once processing.


### PR DESCRIPTION
This PR establishes our Architecture‑as‑Code baseline:
- C4 diagrams (Mermaid) at docs/c4
- ADR process with a template and first two ADRs
- Non‑functional requirements & glossary stubs
- GitHub Action to render Mermaid diagrams to PNG/SVG and upload as artifacts
- Clear README with contribution workflow

------
https://chatgpt.com/codex/tasks/task_e_68a60693e5ec8321b03b65372f3116ad